### PR TITLE
fix node DEP0013: async functions require a callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ module.exports = {
       ).on('close', function () {
         // If on_failure is set, delete the video file unless the tests failed:
         if (videoSettings.delete_on_success && !currentTest.results.failed) {
-          require('fs').unlink(file)
+          require('fs').unlink(file, function(err) {
+            if(err){
+              throw err
+            }
+          })
         }
       })
     }


### PR DESCRIPTION
Running tests with nightwatch-video-recorder displays a deprecation warning:

	.(node:12247) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
	    at makeCallback (fs.js:127:12)
	    at Object.fs.unlink (fs.js:1049:14)
	    at ChildProcess.<anonymous> (/home/jay/src/zing-web/packages/test/node_modules/nightwatch-video-recorder/index.js:74:25)
	    at emitTwo (events.js:131:20)
	    at ChildProcess.emit (events.js:214:7)
	    at maybeClose (internal/child_process.js:925:16)
	    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)

This PR fixes this issue by passing a callback to the `fs.unlink` function call.